### PR TITLE
In detail review of the whole package and comparisson with the original one from ESM-Tools

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,13 @@
 cff-version: 1.2.0
 message: "If you use yaml-provenance, please cite using the metadata below."
 authors:
-- family-names: "Andrés-Martínez"
-  given-names: "Miguel"
-  orcid: "https://orcid.org/0000-0002-1525-5546"
-  affiliation: "Alfred-Wegener-Institut Helmholtz-Zentrum für Polar- und Meeresforschung"
 - family-names: "Gierz"
   given-names: "Paul"
   orcid: "https://orcid.org/0000-0002-4512-087X"
+  affiliation: "Alfred-Wegener-Institut Helmholtz-Zentrum für Polar- und Meeresforschung"]
+- family-names: "Andrés-Martínez"
+  given-names: "Miguel"
+  orcid: "https://orcid.org/0000-0002-1525-5546"
   affiliation: "Alfred-Wegener-Institut Helmholtz-Zentrum für Polar- und Meeresforschung"
 - family-names: "Shafeeque"
   given-names: "Muhammad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ license = "MIT"
 requires-python = ">=3.8"
 authors = [
     { name = "ESM-Tools Development Team" },
-    { email = "miguel.andres-martinez@awi.de", name = "Miguel Andres-Martinez" },
     { email = "paul.gierz@awi.de", name = "Paul Gierz" },
+    { email = "miguel.andres-martinez@awi.de", name = "Miguel Andres-Martinez" },
     { email = "muhammad.shafeeque@awi.de", name = "Muhammad Shafeeque" },
 ]
 maintainers = [
-    { email = "miguel.andres-martinez@awi.de", name = "Miguel Andres-Martinez" },
     { email = "paul.gierz@awi.de", name = "Paul Gierz" },
+    { email = "miguel.andres-martinez@awi.de", name = "Miguel Andres-Martinez" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/yaml_provenance/_decorator.py
+++ b/src/yaml_provenance/_decorator.py
@@ -51,10 +51,15 @@ def keep_provenance_in_recursive_function(func):
                 if config.track_history:
                     output = copy.deepcopy(output)
 
+                # If the new value has an inherited provenance, keep it (i.e. variable
+                # was called: rhs = ${fesom.namelist_dir}, output =
+                # /actual/path/with/provenance/to/be/kept})
                 if hasattr(output, "provenance"):
                     if modify_prov:
                         provenance.extend_and_modified_by(output.provenance, func)
                     output.provenance = provenance
+                # If the rhs.provenance is not None and output has no provenance, keep
+                # the old provenance
                 elif provenance is not None:
                     if modify_prov:
                         provenance.append_last_step_modified_by(func)

--- a/src/yaml_provenance/_decorator.py
+++ b/src/yaml_provenance/_decorator.py
@@ -5,6 +5,7 @@ Decorator for preserving provenance in recursive functions.
 import copy
 
 from ._config import get_config
+from ._provenance import Provenance
 from ._wrapper import wrapper_with_provenance_factory
 
 
@@ -41,7 +42,6 @@ def keep_provenance_in_recursive_function(func):
             if config.track_history:
                 provenance = copy.deepcopy(rhs.provenance)
             else:
-                from ._provenance import Provenance
                 provenance = Provenance(
                     [rhs.provenance[-1]], track_history=False
                 )

--- a/src/yaml_provenance/_dict.py
+++ b/src/yaml_provenance/_dict.py
@@ -12,6 +12,7 @@ from ._provenance import Provenance
 from ._wrapper import wrapper_with_provenance_factory
 
 
+
 class DictWithProvenance(dict):
     """
     A dictionary subclass that tracks provenance for all nested values.
@@ -41,15 +42,20 @@ class DictWithProvenance(dict):
 
     def put_provenance(self, provenance):
         """
-        Recursively transforms every value into its WithProvenance object with
-        corresponding provenance from the ``provenance`` dict (1-to-1 mapping).
+        Recursively transforms every value in ``DictWithProvenance`` into its
+        corresponding WithProvenance object and appends its corresponding
+        ``provenance``. Each value has its corresponding provenance defined in the
+        ``provenance`` dictionary, and this method just groups them together 1-to-1.
 
         Parameters
         ----------
         provenance : dict
-            Provenance dict with same keys as ``self``.
+            The provenance that will be recursively assigned to all leaves of the
+            dictionary tree. The provenance needs to be a ``dict`` with the same keys
+            as ``self`` (same structure) so that it can successfully transfer each
+            provenance value to its corresponding value on ``self`` (1-to-1
+            conrrespondance).
         """
-        from ._list import ListWithProvenance
 
         for key, val in self.items():
             if isinstance(val, dict):
@@ -67,29 +73,57 @@ class DictWithProvenance(dict):
                     val, provenance.get(key, None)
                 )
 
-    def set_provenance(self, provenance):
+    def set_provenance(self, provenance, update_method="extend"):
         """
-        Recursively sets the same ``provenance`` on all nested values.
+        Recursively transforms every value in ``DictWithProvenance`` into its
+        corresponding WithProvenance object and appends the same ``provenance`` to it.
+        Note that this method differs from ``put_provenance`` in that the same
+        ``provenance`` value is applied to the different values of ``self``.
 
         Parameters
         ----------
         provenance : any
-            New provenance value to set.
+            New `provenance value` to be set
+        update_method : str, optional
+            Method to use when updating provenance of existing values. Can be either
+            ``extend`` to append the new provenance to the existing one, or ``update``
+            to update the last provenance entry with new values. Default is ``extend``.
         """
-        from ._list import ListWithProvenance
-
         if not isinstance(provenance, list):
             provenance = [provenance]
 
         for key, val in self.items():
             if isinstance(val, dict):
                 self[key] = DictWithProvenance(val, {}, config=self._config)
-                self[key].set_provenance(provenance)
+                self[key].set_provenance(provenance, update_method=update_method)
             elif isinstance(val, list):
                 self[key] = ListWithProvenance(val, [], config=self._config)
-                self[key].set_provenance(provenance)
+                self[key].set_provenance(provenance, update_method=update_method)
             elif hasattr(val, "provenance"):
-                self[key].provenance.extend(provenance)
+                if update_method == "extend":
+                    self[key].provenance.extend(provenance)
+                elif update_method == "update":
+                    if self[key].provenance[-1]:
+                        self[key].provenance[-1].update(provenance[-1])
+                    else:
+                        self[key].provenance[-1] = provenance[-1]
+                elif update_method == "update_from_switch":
+                    if self[key].provenance[-1]:
+                        old_from_switch = (
+                            self[key].provenance[-1].get("from_switch", [])
+                        )
+                        # Extend the from_switch list with the new entry
+                        if old_from_switch:
+                            provenance[-1]["from_switch"] = (
+                                old_from_switch + provenance[-1].get("from_switch", [])
+                            )
+                        self[key].provenance[-1].update(provenance[-1])
+                    else:
+                        self[key].provenance[-1] = provenance[-1]
+                else:
+                    raise ValueError(
+                        f"Unknown update method {update_method}. Use either 'extend' or 'update'"
+                    )
             else:
                 self[key] = wrapper_with_provenance_factory(val, provenance)
 
@@ -104,19 +138,22 @@ class DictWithProvenance(dict):
 
         Returns
         -------
-        dict
-            Provenance dictionary.
+        provenance_dict : dict
+            A dictionary with a structure and `keys` equivalent to the ``self``
+            dictionary, but with `values` of the `key` leaves those of the provenance
         """
-        from ._list import ListWithProvenance
-        PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)
 
         provenance_dict = {}
+
         for key, val in self.items():
             if isinstance(val, PROVENANCE_MAPPINGS):
                 provenance_dict[key] = val.get_provenance(index=index)
             elif hasattr(val, "provenance"):
                 provenance_dict[key] = val.provenance[index]
             else:
+                # The DictWithProvenance object might have dictionaries inside that
+                # are not instances of that class (i.e. a dictionary added in the
+                # backend). The provenance in this method is then defined as None
                 provenance_dict[key] = None
 
         return provenance_dict
@@ -124,6 +161,23 @@ class DictWithProvenance(dict):
     def _has_real_hierarchy(self):
         """Check if the config has a non-trivial category hierarchy."""
         return len(self._config.category_hierarchy) > 1
+
+    def extract_first_nested_values_provenance(self):
+        """
+        Recursively loops through the dictionary keys and returns the first provenance
+        found in the nested values.
+
+        Returns
+        -------
+        first_provenance : esm_parser.provenance.Provenance
+            The first provenance found in the nested values
+        """
+        first_provenance = None
+        for key, val in self.items():
+            if isinstance(val, PROVENANCE_MAPPINGS):
+                return val.extract_first_nested_values_provenance()
+            elif hasattr(val, "provenance"):
+                return val.provenance[-1]
 
     def __setitem__(self, key, val):
         """
@@ -157,13 +211,14 @@ class DictWithProvenance(dict):
             else:
                 old_category = "backend"
 
-            new_category = None
+            new_category = "backend"
             if hasattr(val, "provenance") and val.provenance and val.provenance[-1]:
                 new_category = val.provenance[-1].get("category", None)
 
             # new_provenance is the same object as old_prov (a reference)
             new_provenance = old_prov
 
+            # If the new value has provenance extend its provenance with the old one
             if hasattr(val, "provenance"):
                 new_provenance.extend_and_modified_by(
                     val.provenance, "dict.__setitem__"
@@ -176,6 +231,7 @@ class DictWithProvenance(dict):
                         old_idx = hierarchy.index(old_category)
                         new_idx = hierarchy.index(new_category)
 
+                        # Handle conflicts if the categories are the same
                         if old_idx == new_idx and old_val != val:
                             # Same category — conflict
                             if config.conflict_resolver is not None:
@@ -280,3 +336,8 @@ class DictWithProvenance(dict):
 
         for key, val in new_provs.items():
             self[key].provenance = val
+
+
+from ._list import ListWithProvenance  # noqa: E402 — deferred to break circular import
+
+PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)

--- a/src/yaml_provenance/_helpers.py
+++ b/src/yaml_provenance/_helpers.py
@@ -3,7 +3,7 @@ Helper functions for provenance operations.
 """
 
 
-def clean_provenance(data):
+def clean_provenance(data, key_transform=None):
     """
     Recursively strips provenance from data, returning plain Python objects.
 
@@ -11,6 +11,9 @@ def clean_provenance(data):
     ----------
     data : any
         Mapping or values with provenance.
+    key_transform : callable, optional
+        Applied to each cleaned dict key before it is inserted into the result.
+        Useful for callers that need to remap keys (e.g. f90nml cogroups).
 
     Returns
     -------
@@ -23,11 +26,18 @@ def clean_provenance(data):
         ), "The provenance object's value and the original value do not match!"
         return data.value
     elif isinstance(data, list):
-        return [clean_provenance(item) for item in data]
+        return [clean_provenance(item, key_transform=key_transform) for item in data]
     elif isinstance(data, dict):
-        return {
-            clean_provenance(key): clean_provenance(value)
-            for key, value in data.items()
-        }
+        result = {}
+        for key, value in data.items():
+            cleaned_key = clean_provenance(key, key_transform=key_transform)
+            dict_key = key_transform(cleaned_key) if key_transform else cleaned_key
+            result[dict_key] = clean_provenance(value, key_transform=key_transform)
+        return result
+    # Clean vars in objects
+    elif hasattr(data, "__dict__"):
+        for key, value in vars(data).items():
+            setattr(data, key, clean_provenance(value, nested=True))
+        return data
     else:
         return data

--- a/src/yaml_provenance/_helpers.py
+++ b/src/yaml_provenance/_helpers.py
@@ -37,7 +37,7 @@ def clean_provenance(data, key_transform=None):
     # Clean vars in objects
     elif hasattr(data, "__dict__"):
         for key, value in vars(data).items():
-            setattr(data, key, clean_provenance(value, nested=True))
+            setattr(data, key, clean_provenance(value))
         return data
     else:
         return data

--- a/src/yaml_provenance/_list.py
+++ b/src/yaml_provenance/_list.py
@@ -32,15 +32,20 @@ class ListWithProvenance(list):
 
     def put_provenance(self, provenance):
         """
-        Recursively transforms every element into its WithProvenance object with
-        corresponding provenance (1-to-1 mapping).
+        Recursively transforms every value in ``ListWithProvenance`` into its
+        corresponding WithProvenance object and appends its corresponding
+        ``provenance``. Each value has its corresponding provenance defined in the
+        ``provenance`` list, and this method just groups them together 1-to-1.
 
         Parameters
         ----------
         provenance : list
-            Provenance list with same length as ``self``.
+            The provenance that will be recursively assigned to all elements of the
+            list. The provenance needs to be a ``list`` with the same number of elements
+            as ``self`` (same structure) so that it can successfully transfer each
+            provenance value to its corresponding value on ``self`` (1-to-1
+            conrrespondance).
         """
-        from ._dict import DictWithProvenance
 
         if not provenance:
             provenance = [{}] * len(self)
@@ -55,29 +60,56 @@ class ListWithProvenance(list):
             else:
                 self[c] = wrapper_with_provenance_factory(elem, provenance[c])
 
-    def set_provenance(self, provenance):
+    def set_provenance(self, provenance, update_method="extend"):
         """
-        Recursively sets the same ``provenance`` on all nested elements.
+        Recursively transforms every value in ``ListWithProvenance`` into its
+        corresponding WithProvenance object and appends the same ``provenance`` to it.
+        Note that this method differs from ``put_provenance`` in that the same
+        ``provenance`` value is applied to the different values of ``self``.
 
         Parameters
         ----------
         provenance : any
-            New provenance value to set.
+            New `provenance value` to be set
+        update_method : str, optional
+            Method to use when updating provenance of existing values. Can be either
+            ``extend`` to append the new provenance to the existing one, or ``update``
+            to update the last provenance entry with new values. Default is ``extend``.
         """
-        from ._dict import DictWithProvenance
-
         if not isinstance(provenance, list):
             provenance = [provenance]
 
         for c, elem in enumerate(self):
             if isinstance(elem, dict):
                 self[c] = DictWithProvenance(elem, {}, config=self._config)
-                self[c].set_provenance(provenance)
+                self[c].set_provenance(provenance, update_method=update_method)
             elif isinstance(elem, list):
                 self[c] = ListWithProvenance(elem, [], config=self._config)
-                self[c].set_provenance(provenance)
+                self[c].set_provenance(provenance, update_method=update_method)
             elif hasattr(elem, "provenance"):
-                self[c].provenance.extend(provenance)
+                if update_method == "extend":
+                    self[c].provenance.extend(provenance)
+                elif update_method == "update":
+                    if self[c].provenance[-1]:
+                        self[c].provenance[-1].update(provenance[-1])
+                    else:
+                        self[c].provenance[-1] = provenance[-1]
+                elif update_method == "update_from_choose":
+                    if self[c].provenance[-1]:
+                        old_from_choose = self[c].provenance[-1].get("from_choose", [])
+                        # Extend the from_choose list with the new entry
+                        if old_from_choose:
+                            provenance[-1]["from_choose"] = (
+                                old_from_choose + provenance[-1].get("from_choose", [])
+                            )
+                        self[c].provenance[-1].update(provenance[-1])
+                    else:
+                        self[c].provenance[-1] = provenance[-1]
+                else:
+                    raise ValueError(
+                        f"Unknown update method {update_method}. Use either 'extend' "
+                        f"or 'update'"
+                    )
             else:
                 self[c] = wrapper_with_provenance_factory(elem, provenance)
 
@@ -92,11 +124,10 @@ class ListWithProvenance(list):
 
         Returns
         -------
-        list
-            Provenance list.
+        provenance_list : list
+            A list with a structure equivalent to that of the ``self`` list, but with
+            the `values` of the provenance of each element
         """
-        from ._dict import DictWithProvenance
-        PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)
 
         provenance_list = []
         for elem in self:
@@ -105,9 +136,29 @@ class ListWithProvenance(list):
             elif hasattr(elem, "provenance"):
                 provenance_list.append(elem.provenance[index])
             else:
+                # The DictWithProvenance object might have dictionaries inside that
+                # are not instances of that class (i.e. a dictionary added in the
+                # backend). The provenance in this method is then defined as None
                 provenance_list.append(None)
 
         return provenance_list
+
+    def extract_first_nested_values_provenance(self):
+        """
+        Recursively loops through the list elements and returns the first provenance
+        found in the nested values.
+
+        Returns
+        -------
+        first_provenance : esm_parser.provenance.Provenance
+            The first provenance found in the nested values
+        """
+        first_provenance = None
+        for elem in self:
+            if isinstance(elem, PROVENANCE_MAPPINGS):
+                return elem.extract_first_nested_values_provenance()
+            elif hasattr(elem, "provenance"):
+                return elem.provenance[-1]
 
     def __setitem__(self, indx, val):
         """
@@ -141,3 +192,8 @@ class ListWithProvenance(list):
         Call the original ``list.__setitem__`` without provenance tracking.
         """
         super().__setitem__(indx, val)
+
+
+from ._dict import DictWithProvenance  # noqa: E402 — deferred to break circular import
+
+PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)

--- a/src/yaml_provenance/_provenance.py
+++ b/src/yaml_provenance/_provenance.py
@@ -11,6 +11,16 @@ class Provenance(list):
     at a point in its history. Supports both full history tracking and lightweight
     mode (at most 1 element).
 
+    To assign the provenance to a value, instanciate it as an attribute of that value
+    (i.e. ``self.provenance = Provenance(my_provenance)``). To be used from the
+    ``WithProvenance`` classes created by ``wrapper_with_provenance_factory``.
+
+    The following class methods provide the extended functionality to lists:
+    * ``self.append_last_step_modified_by``: to duplicate the last element of the list
+        and add to it information about the function that is modifying the value
+    * ``self.extend_and_modified_by``: to extend a list while including in the
+        provenance the function which is responsible for extending it
+
     Parameters
     ----------
     provenance_data : list or dict
@@ -57,7 +67,10 @@ class Provenance(list):
 
     def extend_and_modified_by(self, additional_provenance, func):
         """
-        Extends the current provenance history with ``additional_provenance``.
+        Extends the current provenance history with ``additional_provenance``. This
+        happens when for example a variable comes originally from a file, but then the
+        value is overwritten by another value that comes from a file higher in the
+        hierarchy. This method keeps both history elements.
 
         In lightweight mode, replaces the single element instead of extending.
 
@@ -70,12 +83,16 @@ class Provenance(list):
         """
         if self._track_history:
             new_additional_provenance = additional_provenance
+            # If the new provenance is not identical to the current one extend the
+            # provenance
             if new_additional_provenance is not self:
                 for elem in new_additional_provenance:
                     new_additional_provenance.add_modified_by(
                         elem, func, modified_by="extended_by"
                     )
                 self.extend(new_additional_provenance)
+            # If the new provenance is identical just mark the variable as modified_by
+            # func
             else:
                 self.append_last_step_modified_by(func)
         else:

--- a/src/yaml_provenance/_wrapper.py
+++ b/src/yaml_provenance/_wrapper.py
@@ -9,6 +9,9 @@ from ._config import get_config
 # Registry of dynamically created WithProvenance classes
 _wrapper_registry = {}
 
+# Populated on first call to wrapper_with_provenance_factory to avoid circular imports
+_PROVENANCE_MAPPINGS = None
+
 
 # ========================================================
 # PROVENANCE WRAPPER FACTORY CLASS METHODS AND PROPERTIES
@@ -16,7 +19,8 @@ _wrapper_registry = {}
 @classmethod
 def wrapper_with_provenance_new(cls, *args, **kwargs):
     """
-    ``__new__`` method for WithProvenance classes. Required for ``copy.deepcopy``.
+    ``__new__`` method for WithProvenance classes. Required for ``copy.deepcopy``,
+    without this ``copy.deepcopy`` breaks.
     """
     return super(cls, cls).__new__(cls, args[1])
 
@@ -24,7 +28,8 @@ def wrapper_with_provenance_new(cls, *args, **kwargs):
 def wrapper_with_provenance_init(self, value, provenance=None):
     """
     ``__init__`` method for WithProvenance classes. Adds the ``provenance``
-    attribute as a ``Provenance`` instance.
+    attribute as a ``Provenance`` instance. It also stores the original ``value`` to the
+    ``self.value`` attribute.
 
     Parameters
     ----------
@@ -43,7 +48,14 @@ def wrapper_with_provenance_init(self, value, provenance=None):
 
 @property
 def prop_provenance(self):
-    """Property getter for provenance."""
+    """
+    Property getter for provenance.
+
+    Returns
+    -------
+    self._provenance : esm_parser.provenance.Provenance
+        The provenance history stored in ``self._provenance``
+    """
     return self._provenance
 
 
@@ -52,6 +64,11 @@ def prop_provenance(self, new_provenance):
     """
     Setter for the ``provenance`` property. Ensures the value is a ``Provenance``
     instance.
+
+    Parameters
+    ----------
+    new_provenance : esm_parser.provenance.Provenance
+        New provenance history to be set
 
     Raises
     ------
@@ -98,7 +115,9 @@ class BoolWithProvenance(ProvenanceClassForTheUnsubclassable):
     """
     Class for emulating ``bool`` behaviour with provenance.
 
-    ``isinstance(obj, bool)`` returns ``True``.
+    * ``isinstance(<obj>, bool)`` returns ``True``
+    * ``<True_obj> == True`` returns ``True``
+    * ``<True_obj> is True`` returns ``False``. This is not reproducing the behavior!
     """
 
     @property
@@ -110,7 +129,9 @@ class NoneWithProvenance(ProvenanceClassForTheUnsubclassable):
     """
     Class for emulating ``None`` behaviour with provenance.
 
-    ``isinstance(obj, type(None))`` returns ``True``.
+    * ``isinstance(<obj>, None)`` returns ``True``
+    * ``<obj> == None`` returns ``True``
+    * ``<obj> is None`` returns ``False``. This is not reproducing the behavior!
     """
 
     @property
@@ -142,10 +163,11 @@ def wrapper_with_provenance_factory(value, provenance=None):
     object
         The value wrapped with provenance tracking.
     """
-    # Avoid circular import
-    from ._dict import DictWithProvenance
-    from ._list import ListWithProvenance
-    PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)
+    global _PROVENANCE_MAPPINGS
+    if _PROVENANCE_MAPPINGS is None:
+        from ._dict import DictWithProvenance
+        from ._list import ListWithProvenance
+        _PROVENANCE_MAPPINGS = (DictWithProvenance, ListWithProvenance)
 
     config = get_config()
 
@@ -160,7 +182,7 @@ def wrapper_with_provenance_factory(value, provenance=None):
     elif value is None:
         return NoneWithProvenance(value, provenance)
 
-    elif isinstance(value, PROVENANCE_MAPPINGS):
+    elif isinstance(value, _PROVENANCE_MAPPINGS):
         return value
 
     else:
@@ -180,6 +202,7 @@ def wrapper_with_provenance_factory(value, provenance=None):
                 },
             )
 
+        # Instantiate the subclass with the given value and provenance
         return _wrapper_registry[class_name](value, provenance)
 
 

--- a/src/yaml_provenance/_yaml_dumper.py
+++ b/src/yaml_provenance/_yaml_dumper.py
@@ -67,25 +67,25 @@ def _format_provenance_comment(provenance):
     return comment
 
 
-def _add_eol_comments(commented_config, config):
+def _add_eol_comments(commented_data, data):
     """
     Recursively add end-of-line provenance comments to a ruamel.yaml
     ``CommentedMap`` / ``CommentedSeq``.
 
     Parameters
     ----------
-    commented_config : CommentedMap or CommentedSeq
+    commented_data : CommentedMap or CommentedSeq
         The ruamel.yaml structure to annotate (modified in-place).
-    config : DictWithProvenance or ListWithProvenance
-        The provenance-tracked config to read provenance from.
+    data : DictWithProvenance or ListWithProvenance
+        The provenance-tracked data to read provenance from.
     """
-    if isinstance(commented_config, dict):
-        for key, cvalue in commented_config.items():
-            if not isinstance(config, dict):
+    if isinstance(commented_data, dict):
+        for key, cvalue in commented_data.items():
+            if not isinstance(data, dict):
                 continue
-            pvalue = config.get(key)
-            if pvalue is None and key not in config:
-                commented_config.yaml_add_eol_comment("no provenance", key)
+            pvalue = data.get(key)
+            if pvalue is None and key not in data:
+                commented_data.yaml_add_eol_comment("no provenance", key)
                 continue
             if isinstance(cvalue, (dict, list)):
                 if isinstance(pvalue, (dict, list)):
@@ -93,26 +93,26 @@ def _add_eol_comments(commented_config, config):
             else:
                 provenance = getattr(pvalue, "provenance", [None])[-1]
                 comment = _format_provenance_comment(provenance)
-                commented_config.yaml_add_eol_comment(comment, key)
+                commented_data.yaml_add_eol_comment(comment, key)
 
-    elif isinstance(commented_config, list):
-        for indx, cvalue in enumerate(commented_config):
-            if not isinstance(config, list) or indx >= len(config):
+    elif isinstance(commented_data, list):
+        for indx, cvalue in enumerate(commented_data):
+            if not isinstance(data, list) or indx >= len(data):
                 continue
-            pvalue = config[indx]
+            pvalue = data[indx]
             if isinstance(cvalue, (dict, list)):
                 if isinstance(pvalue, (dict, list)):
                     _add_eol_comments(cvalue, pvalue)
             else:
                 provenance = getattr(pvalue, "provenance", [None])[-1]
                 comment = _format_provenance_comment(provenance)
-                commented_config.yaml_add_eol_comment(comment, indx)
+                commented_data.yaml_add_eol_comment(comment, indx)
 
 
-def dump_yaml(config, filepath=None, stream=None):
+def dump_yaml(data, filepath=None, stream=None):
     """
-    Dump a provenance-tracked config to YAML with end-of-line provenance
-    comments.
+    Dump a provenance-tracked data structure to YAML with end-of-line
+    provenance comments.
 
     Each scalar value is annotated with an end-of-line comment showing the
     source file, line, and column where the value originated. Values added
@@ -123,8 +123,8 @@ def dump_yaml(config, filepath=None, stream=None):
 
     Parameters
     ----------
-    config : DictWithProvenance or ListWithProvenance
-        The provenance-tracked configuration to dump.
+    data : DictWithProvenance or ListWithProvenance
+        The provenance-tracked data to dump.
     filepath : str or Path or None
         Destination file path. Used when ``stream`` is not given.
         If both are ``None``, output goes to stdout.
@@ -158,23 +158,23 @@ def dump_yaml(config, filepath=None, stream=None):
     my_yaml.representer.add_representer(ListWithProvenance, _list_representer)
 
     # Strip provenance wrappers to get plain Python values.
-    config_clean = clean_provenance(config)
+    clean_data = clean_provenance(data)
 
     # Dump to an intermediate string so we can reload into a CommentedMap
     # (ruamel.yaml's round-trip type), which supports adding EOL comments.
     intermediate = StringIO()
-    my_yaml.dump(config_clean, intermediate)
+    my_yaml.dump(clean_data, intermediate)
 
     intermediate.seek(0)
-    config_with_comments = my_yaml.load(intermediate)
+    commented_data = my_yaml.load(intermediate)
 
     # Walk both structures simultaneously and attach provenance comments.
-    _add_eol_comments(config_with_comments, config)
+    _add_eol_comments(commented_data, data)
 
     if stream is not None:
-        my_yaml.dump(config_with_comments, stream)
+        my_yaml.dump(commented_data, stream)
     elif filepath is not None:
         with open(filepath, "w") as f:
-            my_yaml.dump(config_with_comments, f)
+            my_yaml.dump(commented_data, f)
     else:
-        my_yaml.dump(config_with_comments, sys.stdout)
+        my_yaml.dump(commented_data, sys.stdout)

--- a/tests/test_clean_provenance.py
+++ b/tests/test_clean_provenance.py
@@ -1,0 +1,159 @@
+"""
+Tests for clean_provenance.
+"""
+
+from yaml_provenance import clean_provenance, wrapper_with_provenance_factory, DictWithProvenance
+
+
+PROV = {"line": 1, "col": 0}
+
+
+# --- scalar passthrough ---
+
+def test_plain_string_passthrough():
+    assert clean_provenance("hello") == "hello"
+    assert type(clean_provenance("hello")) is str
+
+
+def test_plain_int_passthrough():
+    assert clean_provenance(42) == 42
+
+
+def test_plain_none_passthrough():
+    assert clean_provenance(None) is None
+
+
+# --- wrapped scalars ---
+
+def test_clean_wrapped_string():
+    val = wrapper_with_provenance_factory("hello", PROV)
+    result = clean_provenance(val)
+    assert result == "hello"
+    assert type(result) is str
+
+
+def test_clean_wrapped_int():
+    val = wrapper_with_provenance_factory(42, PROV)
+    result = clean_provenance(val)
+    assert result == 42
+    assert type(result) is int
+
+
+def test_clean_wrapped_float():
+    val = wrapper_with_provenance_factory(3.14, PROV)
+    result = clean_provenance(val)
+    assert result == 3.14
+    assert type(result) is float
+
+
+def test_clean_wrapped_bool():
+    val = wrapper_with_provenance_factory(True, PROV)
+    result = clean_provenance(val)
+    assert result is True
+    assert type(result) is bool
+
+
+def test_clean_wrapped_none():
+    val = wrapper_with_provenance_factory(None, PROV)
+    result = clean_provenance(val)
+    assert result is None
+
+
+# --- lists ---
+
+def test_clean_list_of_wrapped_values():
+    lst = [wrapper_with_provenance_factory(v, PROV) for v in ["a", 1, True]]
+    result = clean_provenance(lst)
+    assert result == ["a", 1, True]
+    assert all(type(r) is type(v) for r, v in zip(result, ["a", 1, True]))
+
+
+def test_clean_nested_list():
+    inner = [wrapper_with_provenance_factory(i, PROV) for i in [1, 2]]
+    outer = [wrapper_with_provenance_factory("x", PROV), inner]
+    result = clean_provenance(outer)
+    assert result == ["x", [1, 2]]
+
+
+def test_clean_plain_list_passthrough():
+    lst = [1, "two", 3.0]
+    result = clean_provenance(lst)
+    assert result == [1, "two", 3.0]
+
+
+# --- dicts ---
+
+def test_clean_dict_with_wrapped_values():
+    d = {
+        "key": wrapper_with_provenance_factory("value", PROV),
+        "num": wrapper_with_provenance_factory(7, PROV),
+    }
+    result = clean_provenance(d)
+    assert result == {"key": "value", "num": 7}
+    assert type(result["key"]) is str
+    assert type(result["num"]) is int
+
+
+def test_clean_dict_with_wrapped_keys():
+    key = wrapper_with_provenance_factory("mykey", PROV)
+    d = {key: "plain_value"}
+    result = clean_provenance(d)
+    assert result == {"mykey": "plain_value"}
+    assert type(list(result.keys())[0]) is str
+
+
+def test_clean_plain_dict_passthrough():
+    d = {"a": 1, "b": "two"}
+    result = clean_provenance(d)
+    assert result == {"a": 1, "b": "two"}
+
+
+def test_clean_nested_dict():
+    d = {
+        "outer": {
+            "inner": wrapper_with_provenance_factory("deep", PROV),
+        }
+    }
+    result = clean_provenance(d)
+    assert result == {"outer": {"inner": "deep"}}
+
+
+# --- key_transform ---
+
+def test_key_transform_applied():
+    d = {"MyKey": wrapper_with_provenance_factory("val", PROV)}
+    result = clean_provenance(d, key_transform=str.lower)
+    assert "mykey" in result
+    assert result["mykey"] == "val"
+
+
+def test_key_transform_on_wrapped_key():
+    key = wrapper_with_provenance_factory("MyKey", PROV)
+    d = {key: "val"}
+    result = clean_provenance(d, key_transform=str.upper)
+    assert "MYKEY" in result
+
+
+# --- DictWithProvenance ---
+
+def test_clean_dict_with_provenance_object():
+    d = DictWithProvenance({"x": wrapper_with_provenance_factory("hello", PROV)}, {})
+    result = clean_provenance(d)
+    assert result == {"x": "hello"}
+    assert type(result) is dict
+
+
+# --- objects with __dict__ ---
+
+def test_clean_object_with_dict():
+    class Obj:
+        def __init__(self):
+            self.x = wrapper_with_provenance_factory("v", PROV)
+            self.n = 42
+
+    obj = Obj()
+    result = clean_provenance(obj)
+    assert result is obj
+    assert result.x == "v"
+    assert type(result.x) is str
+    assert result.n == 42


### PR DESCRIPTION
For this PR, I have compared this package to the original one form https://github.com/esm-tools/esm_tools from where it was exported using Claude. The package is almost identical and diffs are easy to follow through. I have only added back some comments and docstrings that in my view where clearer on the original version. I have also brought back a few small functions, and change some imports to only taking place once (is not going to improve performance though). I've also added new tests for `clean_provenance`.